### PR TITLE
Update eni.tf

### DIFF
--- a/eni.tf
+++ b/eni.tf
@@ -21,7 +21,7 @@ resource "aws_network_interface_attachment" "additional" {
 
 resource "aws_eip" "additional" {
   count             = local.additional_ips_count * var.instance_count
-  vpc               = true
+  domain            = "vpc"
   network_interface = aws_network_interface.additional.*.id[count.index]
   depends_on        = [aws_instance.default]
 }


### PR DESCRIPTION
change deprecated vpc = true to
domain            = "vpc"



│ Warning: Argument is deprecated
│ 
│   with module.amis.module.datapp_instance.aws_eip.additional,
│   on .terraform/modules/amis.datapp_instance/eni.tf line 24, in resource "aws_eip" "additional":
│   24:   vpc               = true
│ 
│ use domain attribute instead
│ 
│ (and one more similar warning elsewhere)